### PR TITLE
weave kilim benchmark and use a valid pause reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ AkkaActorRingBenchmark.ringBenchmark       avgt   50   892,533 ±  50,865  ms/op
 QuasarFiberRingBenchmark.ringBenchmark     avgt   50   832,529 ±  47,586  ms/op
 ```
 
+for `Java(TM) SE Runtime Environment (build 1.8.0_121-b13)` running on `Intel(R) Core(TM) i3-2105 CPU @ 3.10GHz` on `Linux 4.4.0-138-generic x86_64` kernel:
+```
+KilimActorRingBenchmark.Fork.ringBenchmark    avgt    4  656.668 ± 1488.584  ms/op
+KilimActorRingBenchmark.ringBenchmark         avgt    4  492.612 ±   57.829  ms/op
+KilimContinuationRingBenchmark.ringBenchmark  avgt    4   34.866 ±    3.135  ms/op
+KilimFiberRingBenchmark.Fork.ringBenchmark    avgt    4  493.886 ±  218.133  ms/op
+KilimFiberRingBenchmark.ringBenchmark         avgt    4  402.553 ±   97.912  ms/op
+```
+
 License
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <guava.version>26.0-jre</guava.version>
         <jmh-core.version>1.21</jmh-core.version>
         <junit.version>4.12</junit.version>
-        <kilim.version>2.0.0-23</kilim.version>
+        <kilim.version>2.0.0-29</kilim.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.version>1.7.25</slf4j.version>
         <surefire-junit4.version>2.22.0</surefire-junit4.version>
@@ -199,7 +199,16 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.db4j</groupId>
+                <artifactId>kilim</artifactId>
+                <version>${kilim.version}</version>
+                <executions>
+                    <execution>
+                        <goals><goal>weave</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/vlkan/fibertest/KilimContinuationRingBenchmark.java
+++ b/src/main/java/com/vlkan/fibertest/KilimContinuationRingBenchmark.java
@@ -1,0 +1,86 @@
+package com.vlkan.fibertest;
+
+import java.util.LinkedList;
+import kilim.Continuation;
+import kilim.Fiber;
+import kilim.Pausable;
+import kilim.tools.Kilim;
+import org.openjdk.jmh.annotations.Benchmark;
+
+/**
+ * Ring benchmark using Kilim continuations.
+ */
+public class KilimContinuationRingBenchmark extends AbstractRingBenchmark {
+
+    static LinkedList<Continuation> queue = new LinkedList();
+
+    static void scheduler() {
+        for (Continuation cc; ((cc = queue.pollFirst()) != null); )
+            cc.run();
+    }
+    static void resume(InternalFiber task) {
+        if (! task.done)
+            queue.add(task);
+    }
+    
+    public static class InternalFiber extends Continuation {
+        private final int sid;
+        private final int[] sequences;
+        private InternalFiber next;
+        private int sequence;
+        private boolean done;
+        
+
+        private InternalFiber(int id, int[] sequences) {
+            this.sid = id;
+            this.sequences = sequences;
+        }
+
+        @Override
+        public void execute() throws Pausable {
+            while (true) {
+                next.sequence = sequence - 1;
+                resume(next);
+                if (sequence <= 0)
+                    break;
+                Fiber.yield();
+            }
+            done = true;
+            sequences[sid] = sequence;
+        }
+    }
+
+    @Override
+    @Benchmark
+    public int[] ringBenchmark() {
+
+        // Create fibers.
+        int[] sequences = new int[workerCount];
+        InternalFiber[] fibers = new InternalFiber[workerCount];
+        for (int workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+            fibers[workerIndex] = new InternalFiber(workerIndex, sequences);
+        }
+
+        // Set next fiber pointers.
+        for (int workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+            fibers[workerIndex].next = fibers[(workerIndex + 1) % workerCount];
+        }
+
+        // Initiate the ring.
+        InternalFiber firstFiber = fibers[0];
+        firstFiber.sequence = ringSize;
+        resume(firstFiber);
+        
+        scheduler();
+
+        return sequences;
+
+    }
+    
+    public static void main(String[] args) {
+        if (Kilim.trampoline(true,args)) return;
+        int [] seqs = new KilimContinuationRingBenchmark().ringBenchmark();
+    }
+
+
+}

--- a/src/test/java/com/vlkan/fibertest/KilimFiberRingBenchmarkTest.java
+++ b/src/test/java/com/vlkan/fibertest/KilimFiberRingBenchmarkTest.java
@@ -7,11 +7,23 @@ public class KilimFiberRingBenchmarkTest {
 
     @SuppressWarnings("unused")     // entrance for Kilim.run()
     public static void kilimEntrance(String[] ignored) {
-        KilimFiberRingBenchmark benchmark = new KilimFiberRingBenchmark();
-        int[] sequences = benchmark.ringBenchmark();
-        Util.testRingBenchmark(benchmark.workerCount, benchmark.ringSize, sequences);
+        doRing(new KilimContinuationRingBenchmark());
+        doRing(new KilimFiberRingBenchmark());
+        doRing(new KilimFiberRingBenchmark.Fork());
+        doRing(new KilimActorRingBenchmark());
+        doRing(new KilimActorRingBenchmark.Fork());
     }
 
+    static void doRing(AbstractRingBenchmark benchmark) {
+        int[] sequences = null;
+        try {
+            sequences = benchmark.ringBenchmark();
+        }
+        catch (Exception ex) {}
+        Util.testRingBenchmark(benchmark.workerCount, benchmark.ringSize, sequences);
+    }
+    
+    
     @Test
     public void testRingBenchmark() throws Exception {
         Kilim.run("com.vlkan.fibertest.KilimFiberRingBenchmarkTest", "kilimEntrance");


### PR DESCRIPTION
i haven't updated the readme to include the results to avoid future conflicts but a shortened run gives:

```
Benchmark                                  Mode  Cnt     Score   Error  Units
AkkaActorRingBenchmark.ringBenchmark       avgt    2   623.091          ms/op
JavaThreadRingBenchmark.ringBenchmark      avgt    2  6139.337          ms/op
KilimFiberRingBenchmark.ringBenchmark      avgt    2   430.492          ms/op
QuasarActorRingBenchmark.ringBenchmark     avgt    2  2655.926          ms/op
QuasarChannelRingBenchmark.ringBenchmark   avgt    2  1544.488          ms/op
QuasarDataflowRingBenchmark.ringBenchmark  avgt    2  2033.488          ms/op
QuasarFiberRingBenchmark.ringBenchmark     avgt    2   704.593          ms/op
```